### PR TITLE
Add one option: "highlight-icemode.ignoreSelection"

### DIFF
--- a/dist/extension.js
+++ b/dist/extension.js
@@ -34,6 +34,7 @@ var activate = function (context) {
                 return;
             }
             try {
+                var ignoreSelection = config.ignoreSelection;
                 var mathes_1 = {}, match = void 0;
                 var opts = config.ignoreCase ? 'gi' : 'g';
                 if (word && /^\w+$/.test(word)) {
@@ -73,12 +74,12 @@ var activate = function (context) {
                 Object.keys(decorationTypes).forEach(function (v) {
                     var range = mathes_1[v] ? mathes_1[v] : [];
                     range = range.filter(function (o) {
-                        return !(
+                        return ignoreSelection ? !(
                             o.range._start._line === activeEditor.selection._start._line &&
                             o.range._end._line === activeEditor.selection._end._line &&
                             o.range._start._character === activeEditor.selection._start._character &&
                             o.range._end._character === activeEditor.selection._end._character
-                        );
+                        ) : true;
                     });
                     var decorationType = decorationTypes[v];
                     editor.setDecorations(decorationType, range);

--- a/dist/extension.js
+++ b/dist/extension.js
@@ -72,6 +72,14 @@ var activate = function (context) {
                 }
                 Object.keys(decorationTypes).forEach(function (v) {
                     var range = mathes_1[v] ? mathes_1[v] : [];
+                    range = range.filter(function (o) {
+                        return !(
+                            o.range._start._line === activeEditor.selection._start._line &&
+                            o.range._end._line === activeEditor.selection._end._line &&
+                            o.range._start._character === activeEditor.selection._start._character &&
+                            o.range._end._character === activeEditor.selection._end._character
+                        );
+                    });
                     var decorationType = decorationTypes[v];
                     editor.setDecorations(decorationType, range);
                 });

--- a/package.json
+++ b/package.json
@@ -54,6 +54,11 @@
                     "type": "boolean",
                     "default": false,
                     "description": "Highlight selected text with ignore case"
+                },
+                "highlight-icemode.ignoreSelection": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Do not highlight current selection"
                 }
             }
         }


### PR DESCRIPTION
Hi，我在用你这个插件，感觉挺好的，高亮的范围刚好合适。

但是就是装饰的时候，所有相同单词都装饰了，包括当前选中的单词。因为我之前一直用 Sublime Text 3，它就不会给当前单词添加边框，所以我加了个控制选项，勾选上后就不会装饰当前单词了。

你看一下我改的内容吧，要是你觉得也还可以的话，就请麻烦 merge 一下吧，这样我就可以在 VSCode 插件库里直接更新啦。要不然可能还得自己去提交一个新的插件。